### PR TITLE
Fix Rt 77300

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+1.03 Mon Oct 30 13:20:50 CDT 2017
+    - Updated Makefile.PL to fix https://rt.cpan.org/Ticket/Display.html?id=77300
     - Updated the ignore regex in the link-files script to match that of the module.
 1.02 Thu May 17 11:44:41 CDT 2012
     - Changed version to 1.02.

--- a/META.yml
+++ b/META.yml
@@ -29,4 +29,4 @@ resources:
     type: git
     url: git://github.com/mrmuskrat/File-LinkDir.git
     web: https://github.com/mrmuskrat/File-LinkDir/tree
-version: 1.02
+version: 1.03

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ BEGIN {
 use inc::Module::Install;
 
 name           ('File-LinkDir');
-githubmeta;
+githubmeta();
 all_from       ('lib/File/LinkDir.pm');
 requires       ('File::Path'   => '2.07');
 test_requires  ('Test::More'   => '0');

--- a/lib/File/LinkDir.pm
+++ b/lib/File/LinkDir.pm
@@ -9,7 +9,7 @@ use File::Find;
 use File::Path qw<remove_tree make_path>;
 use File::Spec::Functions qw<catpath splitpath>;
 
-our $VERSION = '1.02';
+our $VERSION = '1.03';
 $VERSION = eval $VERSION;
 
 sub new


### PR DESCRIPTION
If "githubmeta" was being seen as a bareword then add parentheses to make it more obvious that it is a subroutine call.